### PR TITLE
feat(LinkDecorator): new expanded link with custom domains

### DIFF
--- a/src/decorators/index.js
+++ b/src/decorators/index.js
@@ -3,7 +3,7 @@
  * @flow strict
  */
 
-import { link } from './link';
+import { link, getExpandedLink } from './link';
 import { emoji, namedEmoji } from './emoji';
 import { createRegexDecorator, createBetweenDecorator } from './utils';
 
@@ -49,6 +49,6 @@ const decorators = [
   namedEmoji,
 ];
 
-export { link, emoji, namedEmoji };
+export { link, emoji, namedEmoji, getExpandedLink };
 
 export default decorators;

--- a/src/decorators/index.test.js
+++ b/src/decorators/index.test.js
@@ -12,6 +12,7 @@ import {
   mention,
   emoji,
   namedEmoji,
+  getExpandedLink,
 } from './index';
 
 export function testDecorator(decorator, cases) {
@@ -247,6 +248,29 @@ describe('decorators', () => {
           replace: 'www.some-site.org/здесь_Заголовок',
           options: { url: 'http://www.some-site.org/здесь_Заголовок' },
         },
+      ],
+    },
+  ]);
+
+  testDecorator(getExpandedLink(['local']), [
+    {
+      text: 'http://gazprom.local, local link',
+      result: [
+        {
+          start: 0,
+          end: 20,
+          replace: 'http://gazprom.local',
+        }
+      ],
+    },
+    {
+      text: 'http://gazprom.local/адресс_по-русски, local link',
+      result: [
+        {
+          start: 0,
+          end: 37,
+          replace: 'http://gazprom.local/адресс_по-русски',
+        }
       ],
     },
   ]);

--- a/src/decorators/link.js
+++ b/src/decorators/link.js
@@ -140,7 +140,7 @@ function linkStrategy(text: string, newDomains: ?Array<string>) {
 export const link: Decorator = {
   name: 'link',
   strategy(text: string) {
-    return linkStrategy(text);
+    return linkStrategy(text, null);
   }
 };
 

--- a/src/decorators/link.js
+++ b/src/decorators/link.js
@@ -137,14 +137,14 @@ function linkStrategy(text: string, newDomains: ?Array<string>) {
   return ranges;
 }
 
-export const link = {
+export const link: Decorator = {
   name: 'link',
   strategy(text: string) {
     return linkStrategy(text);
   }
 };
 
-export function getExpandedLink(newDomains: Array<string>) {
+export function getExpandedLink(newDomains: Array<string>): Decorator {
   return {
     name: 'link',
     strategy(text: string) {

--- a/src/decorators/link.js
+++ b/src/decorators/link.js
@@ -6,7 +6,6 @@
 import tlds from 'tlds';
 import type { Decorator } from '../types';
 
-const domains = new Set(tlds);
 const pattern = /(?:\[(.+)\]\()?((?:(https?):\/\/)?(?:www\.)?(?:[-а-яёA-z0-9]+\.)+([а-яёA-z]{2,18})(?:[-А-яёA-z0-9._~:\/\?#\[\]@!$&'()\*\+,;=%]+)?)/gi;
 
 function isPunctuation(char: string): boolean {
@@ -52,88 +51,104 @@ function normalizeUrl(url: string): string {
   return `http://${url}`;
 }
 
-export const link: Decorator = {
-  name: 'link',
-  strategy(text: string) {
-    const ranges = [];
+function createDomainsList(newDomains: ?Array<string>) {
+  const domainsList = new Set(tlds);
 
-    let matches;
-    for (
-      let matches = pattern.exec(text);
-      matches !== null;
-      matches = pattern.exec(text)
-    ) {
-      const [, name, url, protocol, domain] = matches;
-
-      if (!domains.has(domain)) {
-        continue;
-      }
-
-      let link = url;
-      const braceDepth = getBraceDepth(link);
-      if (braceDepth > 0) {
-        if (name) {
-          link = link.slice(0, link.length - braceDepth + 1);
-        } else {
-          link = link.slice(0, link.length - braceDepth);
-        }
-      }
-
-      const start = matches.index;
-      const end = start + link.length;
-
-      const lastLinkChar = link.charAt(link.length - 1);
-
-      if (name && lastLinkChar === ')') {
-        const rawUrl = link.slice(0, link.length - 1);
-
-        ranges.push({
-          start,
-          end: end + name.length + 3,
-          replace: name,
-          options: {
-            url: protocol ? rawUrl : normalizeUrl(rawUrl),
-          },
-        });
-      } else if (isPunctuation(lastLinkChar)) {
-        ranges.push({
-          start,
-          end: end - 1,
-          replace: link.slice(0, link.length - 1),
-          ...(protocol
-            ? {}
-            : {
-                options: {
-                  url: normalizeUrl(link.slice(0, link.length - 1)),
-                },
-              }),
-        });
-      } else {
-        ranges.push({
-          start,
-          end,
-          replace: link,
-          ...(protocol
-            ? {}
-            : {
-                options: {
-                  url: normalizeUrl(link),
-                },
-              }),
-        });
-      }
-    }
-
-    return ranges;
-  },
-};
-
-export function getExpandedLink(newDomains: Array<string>): Decorator {
   if (newDomains && newDomains.length) {
     newDomains.forEach((newDomain: string) => {
-      domains.add(newDomain);
+      domainsList.add(newDomain);
     });
   }
 
-  return link;
+  return domainsList;
+}
+
+function linkStrategy(text: string, newDomains: ?Array<string>) {
+  const ranges = [];
+  const domains = createDomainsList(newDomains);
+
+  let matches;
+  for (
+    let matches = pattern.exec(text);
+    matches !== null;
+    matches = pattern.exec(text)
+  ) {
+    const [, name, url, protocol, domain] = matches;
+
+    if (!domains.has(domain)) {
+      continue;
+    }
+
+    let link = url;
+    const braceDepth = getBraceDepth(link);
+    if (braceDepth > 0) {
+      if (name) {
+        link = link.slice(0, link.length - braceDepth + 1);
+      } else {
+        link = link.slice(0, link.length - braceDepth);
+      }
+    }
+
+    const start = matches.index;
+    const end = start + link.length;
+
+    const lastLinkChar = link.charAt(link.length - 1);
+
+    if (name && lastLinkChar === ')') {
+      const rawUrl = link.slice(0, link.length - 1);
+
+      ranges.push({
+        start,
+        end: end + name.length + 3,
+        replace: name,
+        options: {
+          url: protocol ? rawUrl : normalizeUrl(rawUrl),
+        },
+      });
+    } else if (isPunctuation(lastLinkChar)) {
+      ranges.push({
+        start,
+        end: end - 1,
+        replace: link.slice(0, link.length - 1),
+        ...(protocol
+          ? {}
+          : {
+            options: {
+              url: normalizeUrl(link.slice(0, link.length - 1)),
+            },
+          }),
+      });
+    } else {
+      ranges.push({
+        start,
+        end,
+        replace: link,
+        ...(protocol
+          ? {}
+          : {
+            options: {
+              url: normalizeUrl(link),
+            },
+          }),
+      });
+    }
+  }
+
+  return ranges;
+}
+
+export const link = {
+  name: 'link',
+  strategy(text: string) {
+    return linkStrategy(text);
+  }
+};
+
+export function getExpandedLink(newDomains: Array<string>) {
+  return {
+    name: 'link',
+    strategy(text: string) {
+      return linkStrategy(text, newDomains);
+    }
+  }
 }

--- a/src/decorators/link.js
+++ b/src/decorators/link.js
@@ -127,3 +127,13 @@ export const link: Decorator = {
     return ranges;
   },
 };
+
+export function getExpandedLink(newDomains: Array<string>): Decorator {
+  if (newDomains && newDomains.length) {
+    newDomains.forEach((newDomain) => {
+      domains.add(newDomain);
+    });
+  }
+
+  return link;
+}

--- a/src/decorators/link.js
+++ b/src/decorators/link.js
@@ -130,7 +130,7 @@ export const link: Decorator = {
 
 export function getExpandedLink(newDomains: Array<string>): Decorator {
   if (newDomains && newDomains.length) {
-    newDomains.forEach((newDomain) => {
+    newDomains.forEach((newDomain: string) => {
       domains.add(newDomain);
     });
   }

--- a/src/decorators/link.js
+++ b/src/decorators/link.js
@@ -140,7 +140,7 @@ function linkStrategy(text: string, newDomains?: Array<string>) {
 export const link: Decorator = {
   name: 'link',
   strategy(text: string) {
-    return linkStrategy(text, null);
+    return linkStrategy(text);
   }
 };
 

--- a/src/decorators/link.js
+++ b/src/decorators/link.js
@@ -51,7 +51,7 @@ function normalizeUrl(url: string): string {
   return `http://${url}`;
 }
 
-function createDomainsList(newDomains: ?Array<string>) {
+function createDomainsList(newDomains?: Array<string>) {
   const domainsList = new Set(tlds);
 
   if (newDomains && newDomains.length) {
@@ -63,7 +63,7 @@ function createDomainsList(newDomains: ?Array<string>) {
   return domainsList;
 }
 
-function linkStrategy(text: string, newDomains: ?Array<string>) {
+function linkStrategy(text: string, newDomains?: Array<string>) {
   const ranges = [];
   const domains = createDomainsList(newDomains);
 


### PR DESCRIPTION
We need to parse local gazprom resources with .local domain ("http://portal.gazprom-neft.local/" for example). At this time decorator link use library "tlds" with list of available domains, and .local not included in this library.
So this getExpandedList method extend tlds-list with new added domains, so we can use in gpn-ee-messenger decorator with custom domains.
